### PR TITLE
Accept a period immediately following a month name

### DIFF
--- a/parser.peg
+++ b/parser.peg
@@ -103,7 +103,7 @@ Day
 MonthName
     = m:("jan"/ "feb" / "mar" / "apr" /
           "may" / "jun" / "jul" / "aug" /
-          "sep" / "oct" / "nov" / "dec") { return m; }
+          "sep" / "oct" / "nov" / "dec") "."? { return m; }
 
 DateSeparator
     = _* "-" _*


### PR DESCRIPTION
e.g. `jan. 31, 2016`. As detailed in issue #9, Chrome, Safari, IE11, and Edge accept a period after the month name (even if the month name is not an abbreviation):

* Firefox does not accept a period after month names like `Jan.`. This is [Firefox bug 1175778](https://bugzilla.mozilla.org/show_bug.cgi?id=1175778).
* IE11 and Edge accept a period immediately following a month name (no spaces) like `Jan.` and `January.` but not `Jan .` or `January .`.
* Chrome and Safari will accept periods and random crap pretty much anywhere in month name, e.g. `JanZ ..Zu.aZ.r.Zzy.Z. 1 .... 2016` is parsed as 2016-01-01.