### PR TITLE
Millisecond values can have 1–3 digits

### DIFF
--- a/parser.peg
+++ b/parser.peg
@@ -29,7 +29,11 @@ Z
     }
     / "Z" { return {sign: "+", hh: "00", mm: "00"}; }
 
-Msec = sss:(N? N? N)      { return sss.join(''); }
+Msec
+    = sss:(N N N) { return parseInt(sss.join('')); }
+    / sss:(N N)   { return parseInt(sss.join('')) * 10; }
+    / sss:N       { return parseInt(sss) * 100; }
+
 Sec  = s:ZeroToFiftyNine  { return s.join(''); }
 Min  = m:ZeroToFiftyNine  { return m.join(''); }
 Hr   = h:ZeroToTwentyFour { return h.join(''); }


### PR DESCRIPTION
This PR fixes issue #10.

* `2016-01-31T00:01:23.4` will be parsed as 400 milliseconds.
* `2016-01-31T00:01:23.40` will be parsed as 400 milliseconds.
* `2016-01-31T00:01:23.040` will be parsed as 40 milliseconds.

This PR also changes Msec's type from a string to a number. This avoids problems with leading zeros so we can return `40` milliseconds instead of `"040"` milliseconds.